### PR TITLE
fix(bower.json) package name corrected

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-	"name": "jquery finnish hyphenator",
+	"name": "jquery-finnish-hyphenator",
 	"version": "0.2.2",
 	"homepage": "https://github.com/vepasto/finnish-hyphenator",
 	"authors": [


### PR DESCRIPTION
- Replace whitespace characters with dash characters.

**More details:**
- [bower.json specification](https://github.com/bower/spec/blob/master/json.md)
- [Creating Bower Packages](https://bower.io/docs/creating-packages/)

**Related issue:**
- #6 _"Bower package nimessä välilyöntejä"_